### PR TITLE
Fix runner

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,9 +11,4 @@
   ]
 }.
 
-{ plugins
-, [ { rebar3_clojerl
-    , {git, "https://github.com/clojerl/rebar3_clojerl", {branch, "master"}}
-    }
-  ]
-}.
+{plugins, [rebar3_clojerl]}.

--- a/src/main/clojure/clojure/test/generative/runner.clje
+++ b/src/main/clojure/clojure/test/generative/runner.clje
@@ -9,6 +9,7 @@
 
 (ns clojure.test.generative.runner
   (:require
+   [clojure.tools.namespace :as ns]
    [clojure.data.generators :as gen]
    [clojure.test.generative :as tgen]
    [clojure.string :as str]))
@@ -75,94 +76,6 @@
         ns-symbol (symbol ns-name)]
     ns-symbol))
 
-(defn clojure-source-file?
-  "DEPRECATED; moved to clojure.tools.namespace.file
-
-  Returns true if file is a normal file with a .clj or .cljc extension."
-  {:deprecated "0.2.1"
-   :added "0.1.0"}
-  [file]
-  (and (filelib/is_regular file)
-       (#{".clje" ".cljc"} (filename/extension file))))
-
-(defn find-clojure-sources-in-dir
-  "DEPRECATED; moved to clojure.tools.namespace.find
-
-  Searches recursively under dir for Clojure source files (.clje, .cljc).
-  Returns a sequence of paths, in breadth-first sort order."
-  {:deprecated "0.2.1"
-   :added "0.1.0"}
-  [dir]
-  ;; Use sort by absolute path to get breadth-first search.
-  (sort-by #(filename/absname %)
-           (filter clojure-source-file? (file-seq dir))))
-
-(defn comment?
-  "DEPRECATED; moved to clojure.tools.namespace.parse
-
-  Returns true if form is a (comment ...)"
-  {:deprecated "0.2.1"
-   :added "0.1.0"}
-  [form]
-  (and (list? form) (= 'comment (first form))))
-
-(defn ns-decl?
-  "DEPRECATED; moved to clojure.tools.namespace.parse
-
-  Returns true if form is a (ns ...) declaration."
-  {:deprecated "0.2.1"
-   :added "0.1.0"}
-  [form]
-  (and (list? form) (= 'ns (first form))))
-
-(defn read-ns-decl
-  "DEPRECATED; moved to clojure.tools.namespace.parse
-
-  Attempts to read a (ns ...) declaration from rdr, and returns the
-  unevaluated form.  Returns nil if read fails or if a ns declaration
-  cannot be found.  The ns declaration must be the first Clojure form
-  in the file, except for (comment ...)  forms."
-  {:deprecated "0.2.1"
-   :added "0.1.0"}
-  [^erlang.io.PushbackReader rdr]
-  (try
-   (loop [] (let [form (doto (read rdr) str)]
-              (cond
-                (ns-decl? form) form
-                (comment? form) (recur)
-                :else nil)))
-   (catch clojerl.Error e nil)))
-
-(defn read-file-ns-decl
-  "DEPRECATED; moved to clojure.tools.namespace.file
-
-  Attempts to read a (ns ...) declaration from file, and returns the
-  unevaluated form.  Returns nil if read fails, or if the first form
-  is not a ns declaration."
-  {:deprecated "0.2.1"
-   :added "0.1.0"}
-  [file]
-  (with-open [rdr (erlang.io.PushbackReader. (erlang.io.File. file))]
-    (read-ns-decl rdr)))
-
-(defn find-ns-decls-in-dir
-  "DEPRECATED; moved to clojure.tools.namespace.find
-
-  Searches dir recursively for (ns ...) declarations in Clojure
-  source files; returns the unevaluated ns declarations."
-  {:deprecated "0.2.1"
-   :added "0.1.0"}
-  [dir]
-  (filter identity (map read-file-ns-decl (find-clojure-sources-in-dir dir))))
-
-(defn find-namespaces-in-dir
-  "DEPRECATED; moved to clojure.tools.namespace.find
-
-  Searches dir recursively for (ns ...) declarations in Clojure
-  source files; returns the symbol names of the declared namespaces."
-  [dir]
-  (map second (find-ns-decls-in-dir dir)))
-
 (defn- find-vars-in-namespaces
   [& nses]
   (when nses
@@ -170,7 +83,7 @@
 
 (defn- find-vars-in-dirs
   [& dirs]
-  (let [nses (mapcat #(find-namespaces-in-dir %) dirs)]
+  (let [nses (mapcat #(ns/find-namespaces-in-dir %) dirs)]
     (doseq [ns nses] (require ns))
     (apply find-vars-in-namespaces nses)))
 
@@ -252,7 +165,7 @@
   "Returns all tests in dirs"
   [dirs]
   (let [load (fn [s] (require s) s)]
-    (->> (mapcat #(find-namespaces-in-dir %) dirs)
+    (->> (mapcat #(ns/find-namespaces-in-dir %) dirs)
          (map load)
          (apply find-vars-in-namespaces)
          (mapcat get-tests))))

--- a/src/main/clojure/clojure/test/generative/runner.clje
+++ b/src/main/clojure/clojure/test/generative/runner.clje
@@ -30,7 +30,10 @@
   []
   (reduce
    (fn [m [prop path coerce default]]
-     (let [val (os/getenv prop "")]
+     (let [val (-> prop
+                   erlang/binary_to_list
+                   (os/getenv #erl"")
+                   erlang/list_to_binary)]
        (if (seq val)
          (assoc-in m path (coerce val))
          (assoc-in m path default))))
@@ -72,8 +75,93 @@
         ns-symbol (symbol ns-name)]
     ns-symbol))
 
-(defn find-namespaces-in-dir [dir]
-  [])
+(defn clojure-source-file?
+  "DEPRECATED; moved to clojure.tools.namespace.file
+
+  Returns true if file is a normal file with a .clj or .cljc extension."
+  {:deprecated "0.2.1"
+   :added "0.1.0"}
+  [file]
+  (and (filelib/is_regular file)
+       (#{".clje" ".cljc"} (filename/extension file))))
+
+(defn find-clojure-sources-in-dir
+  "DEPRECATED; moved to clojure.tools.namespace.find
+
+  Searches recursively under dir for Clojure source files (.clje, .cljc).
+  Returns a sequence of paths, in breadth-first sort order."
+  {:deprecated "0.2.1"
+   :added "0.1.0"}
+  [dir]
+  ;; Use sort by absolute path to get breadth-first search.
+  (sort-by #(filename/absname %)
+           (filter clojure-source-file? (file-seq dir))))
+
+(defn comment?
+  "DEPRECATED; moved to clojure.tools.namespace.parse
+
+  Returns true if form is a (comment ...)"
+  {:deprecated "0.2.1"
+   :added "0.1.0"}
+  [form]
+  (and (list? form) (= 'comment (first form))))
+
+(defn ns-decl?
+  "DEPRECATED; moved to clojure.tools.namespace.parse
+
+  Returns true if form is a (ns ...) declaration."
+  {:deprecated "0.2.1"
+   :added "0.1.0"}
+  [form]
+  (and (list? form) (= 'ns (first form))))
+
+(defn read-ns-decl
+  "DEPRECATED; moved to clojure.tools.namespace.parse
+
+  Attempts to read a (ns ...) declaration from rdr, and returns the
+  unevaluated form.  Returns nil if read fails or if a ns declaration
+  cannot be found.  The ns declaration must be the first Clojure form
+  in the file, except for (comment ...)  forms."
+  {:deprecated "0.2.1"
+   :added "0.1.0"}
+  [^erlang.io.PushbackReader rdr]
+  (try
+   (loop [] (let [form (doto (read rdr) str)]
+              (cond
+                (ns-decl? form) form
+                (comment? form) (recur)
+                :else nil)))
+   (catch clojerl.Error e nil)))
+
+(defn read-file-ns-decl
+  "DEPRECATED; moved to clojure.tools.namespace.file
+
+  Attempts to read a (ns ...) declaration from file, and returns the
+  unevaluated form.  Returns nil if read fails, or if the first form
+  is not a ns declaration."
+  {:deprecated "0.2.1"
+   :added "0.1.0"}
+  [file]
+  (with-open [rdr (erlang.io.PushbackReader. (erlang.io.File. file))]
+    (read-ns-decl rdr)))
+
+(defn find-ns-decls-in-dir
+  "DEPRECATED; moved to clojure.tools.namespace.find
+
+  Searches dir recursively for (ns ...) declarations in Clojure
+  source files; returns the unevaluated ns declarations."
+  {:deprecated "0.2.1"
+   :added "0.1.0"}
+  [dir]
+  (filter identity (map read-file-ns-decl (find-clojure-sources-in-dir dir))))
+
+(defn find-namespaces-in-dir
+  "DEPRECATED; moved to clojure.tools.namespace.find
+
+  Searches dir recursively for (ns ...) declarations in Clojure
+  source files; returns the symbol names of the declared namespaces."
+  [dir]
+  (map second (find-ns-decls-in-dir dir)))
 
 (defn- find-vars-in-namespaces
   [& nses]
@@ -82,7 +170,7 @@
 
 (defn- find-vars-in-dirs
   [& dirs]
-  (let [nses (mapcat #(find-namespaces-in-dir (erlang.io.File. %)) dirs)]
+  (let [nses (mapcat #(find-namespaces-in-dir %) dirs)]
     (doseq [ns nses] (require ns))
     (apply find-vars-in-namespaces nses)))
 
@@ -164,7 +252,7 @@
   "Returns all tests in dirs"
   [dirs]
   (let [load (fn [s] (require s) s)]
-    (->> (mapcat #(find-namespaces-in-dir (erlang.io.File. %)) dirs)
+    (->> (mapcat #(find-namespaces-in-dir %) dirs)
          (map load)
          (apply find-vars-in-namespaces)
          (mapcat get-tests))))

--- a/src/main/clojure/clojure/tools/namespace.clje
+++ b/src/main/clojure/clojure/tools/namespace.clje
@@ -1,0 +1,89 @@
+(ns clojure.tools.namespace)
+
+(defn clojure-source-file?
+  "DEPRECATED; moved to clojure.tools.namespace.file
+
+  Returns true if file is a normal file with a .clj or .cljc extension."
+  {:deprecated "0.2.1"
+   :added "0.1.0"}
+  [file]
+  (and (filelib/is_regular file)
+       (#{".clje" ".cljc"} (filename/extension file))))
+
+(defn find-clojure-sources-in-dir
+  "DEPRECATED; moved to clojure.tools.namespace.find
+
+  Searches recursively under dir for Clojure source files (.clje, .cljc).
+  Returns a sequence of paths, in breadth-first sort order."
+  {:deprecated "0.2.1"
+   :added "0.1.0"}
+  [dir]
+  ;; Use sort by absolute path to get breadth-first search.
+  (sort-by #(filename/absname %)
+           (filter clojure-source-file? (file-seq dir))))
+
+(defn comment?
+  "DEPRECATED; moved to clojure.tools.namespace.parse
+
+  Returns true if form is a (comment ...)"
+  {:deprecated "0.2.1"
+   :added "0.1.0"}
+  [form]
+  (and (list? form) (= 'comment (first form))))
+
+(defn ns-decl?
+  "DEPRECATED; moved to clojure.tools.namespace.parse
+
+  Returns true if form is a (ns ...) declaration."
+  {:deprecated "0.2.1"
+   :added "0.1.0"}
+  [form]
+  (and (list? form) (= 'ns (first form))))
+
+(defn read-ns-decl
+  "DEPRECATED; moved to clojure.tools.namespace.parse
+
+  Attempts to read a (ns ...) declaration from rdr, and returns the
+  unevaluated form.  Returns nil if read fails or if a ns declaration
+  cannot be found.  The ns declaration must be the first Clojure form
+  in the file, except for (comment ...)  forms."
+  {:deprecated "0.2.1"
+   :added "0.1.0"}
+  [^erlang.io.PushbackReader rdr]
+  (try
+   (loop [] (let [form (doto (read rdr) str)]
+              (cond
+                (ns-decl? form) form
+                (comment? form) (recur)
+                :else nil)))
+   (catch clojerl.Error e nil)))
+
+(defn read-file-ns-decl
+  "DEPRECATED; moved to clojure.tools.namespace.file
+
+  Attempts to read a (ns ...) declaration from file, and returns the
+  unevaluated form.  Returns nil if read fails, or if the first form
+  is not a ns declaration."
+  {:deprecated "0.2.1"
+   :added "0.1.0"}
+  [file]
+  (with-open [rdr (erlang.io.PushbackReader. (erlang.io.File. file))]
+    (read-ns-decl rdr)))
+
+(defn find-ns-decls-in-dir
+  "DEPRECATED; moved to clojure.tools.namespace.find
+
+  Searches dir recursively for (ns ...) declarations in Clojure
+  source files; returns the unevaluated ns declarations."
+  {:deprecated "0.2.1"
+   :added "0.1.0"}
+  [dir]
+  (filter identity (map read-file-ns-decl (find-clojure-sources-in-dir dir))))
+
+(defn find-namespaces-in-dir
+  "DEPRECATED; moved to clojure.tools.namespace.find
+
+  Searches dir recursively for (ns ...) declarations in Clojure
+  source files; returns the symbol names of the declared namespaces."
+  [dir]
+  (map second (find-ns-decls-in-dir dir)))


### PR DESCRIPTION
The code was not working since it required `tools.namespace`. Instead of porting the whole project, this PR only brings the (deprecated) `clojure.tools.namespace` namespace from the upstream project [here](https://github.com/clojure/tools.namespace).